### PR TITLE
CI AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,30 @@
+build: off
+cache:
+    - c:\php -> appveyor.yml
+    - '%LOCALAPPDATA%\Composer\files -> appveyor.yml'
+clone_folder: c:\projects\texy
+
+init:
+    - SET PATH=c:\php;%PATH%
+    - SET COMPOSER_NO_INTERACTION=1
+    - SET PHP=1
+    - SET ANSICON=121x90 (121x90)
+
+install:
+    - IF EXIST c:\php (SET PHP=0) ELSE (mkdir c:\php)
+    - IF %PHP%==1 cd c:\php
+    - IF %PHP%==1 appveyor DownloadFile http://windows.php.net/downloads/releases/php-5.6.15-Win32-VC11-x86.zip
+    - IF %PHP%==1 7z x php-5.6.15-Win32-VC11-x86.zip -y >nul
+    - IF %PHP%==1 copy /Y php.ini-development php.ini
+    - IF %PHP%==1 echo max_execution_time=1200 >> php.ini
+    - IF %PHP%==1 echo date.timezone="UTC" >> php.ini
+    - IF %PHP%==1 echo extension_dir=ext >> php.ini
+    - IF %PHP%==1 echo extension=php_openssl.dll >> php.ini
+    - IF %PHP%==1 del /Q *.zip
+    - IF %PHP%==1 cd ..
+    - cd c:\projects\texy
+    - appveyor DownloadFile https://getcomposer.org/composer.phar
+    - php composer.phar install --prefer-dist --no-interaction --no-progress --ansi
+
+test_script:
+    - tests\RunTests.bat -s --colors 0 tests

--- a/readme.md
+++ b/readme.md
@@ -3,6 +3,7 @@ Texy!   [![Buy me a coffee](https://files.nette.org/images/coffee1s.png)](https:
 
 [![Downloads this Month](https://img.shields.io/packagist/dm/texy/texy.svg)](https://packagist.org/packages/texy/texy)
 [![Build Status](https://travis-ci.org/dg/texy.svg?branch=master)](https://travis-ci.org/dg/texy)
+[![Build Status Windows](https://ci.appveyor.com/api/projects/status/github/dg/texy?branch=master&svg=true)](https://ci.appveyor.com/project/dg/texy/branch/master)
 [![Latest Stable Version](https://poser.pugx.org/dg/texy/v/stable)](https://github.com/dg/texy/releases)
 [![License](https://img.shields.io/badge/license-New%20BSD-blue.svg)](https://github.com/dg/texy/blob/master/license.md)
 


### PR DESCRIPTION
This PR adds a config file for AppVeyor which is a CI similar to travis, except they run the builds on Windows machines. Therefore any possible incompatibilites can be easily discovered.

You can see the build output here https://ci.appveyor.com/project/mhujer/texy/build/job/3pu7cfwodc77gg5p

To integrate it with this project, it is necessary to login to https://ci.appveyor.com/ using github account and enable the build for this repo.

(Symfony has recently started to use AppVeyor - https://github.com/symfony/symfony/pull/15575, that's where most of the config comes from)