### PR TITLE
Make docblock say $widthDelta can also be FALSE

### DIFF
--- a/src/Texy/Modules/FigureModule.php
+++ b/src/Texy/Modules/FigureModule.php
@@ -25,7 +25,7 @@ final class FigureModule extends Texy\Module
 	/** @var string  right-floated box CSS class */
 	public $rightClass;
 
-	/** @var int  how calculate div's width */
+	/** @var int|FALSE  how calculate div's width */
 	public $widthDelta = 10;
 
 


### PR DESCRIPTION
- bug fix? no
- new feature? no
- BC break? no

`$widthDelta` is slated for removal in [Texy 3](https://github.com/dg/texy/pull/39/commits/e86b799a776e8f91e54e39455886e7fd2cea473d) but until that happens it can also be `FALSE`, as seen on [line 100](https://github.com/dg/texy/blob/9fc80c9f297f651fe1bddcd8937abdbb5be4bc69/src/Texy/Modules/FigureModule.php#L100
), the docblock should reflect it.

Thanks for considering this simple fix.