### PR TITLE
Tests: added failing test for image center syntax

### DIFF
--- a/tests/Texy/expected/special.html
+++ b/tests/Texy/expected/special.html
@@ -127,6 +127,8 @@
 
 <p>[* &lt;]</p>
 
+<div style="text-align:center"><img src="../images/image" alt="" /></div>
+
 <p><em>V zahradě rozkoší zachmuřen<br />
 <a href="http://en.wikipedia.org/wiki/Hieronymus_Bosch">Hieronymus Bosch</a><br />
 v přístěnku Bestiář Aristotelův</em></p>

--- a/tests/Texy/sources/special.texy
+++ b/tests/Texy/sources/special.texy
@@ -116,6 +116,8 @@ m_2n
 
 [* <]
 
+.<>
+[* image *]
 
 
 //V zahradě rozkoší zachmuřen


### PR DESCRIPTION
After commit [9fc80c9: FigureModule: matches standalone images, instead of imageModule (BC break)](https://github.com/dg/texy/commit/9fc80c9f297f651fe1bddcd8937abdbb5be4bc69), I'm not able to use this syntax:

```code
 .<>
[* image *]
```

It worked before, and I've used it a lot. And I thought it is preferred syntax. 

Is anything I can do, to make it work again? Or I must change document?
