### PR TITLE
Added underscores support to element attributes

### DIFF
--- a/src/Texy/Modules/HtmlModule.php
+++ b/src/Texy/Modules/HtmlModule.php
@@ -30,7 +30,7 @@ final class HtmlModule extends Texy\Module
 
 		$texy->registerLinePattern(
 			[$this, 'patternTag'],
-			'#<(/?)([a-z][a-z0-9_:-]{0,50})((?:\s++[a-z0-9:-]++|=\s*+"[^"'.Patterns::MARK.']*+"|=\s*+\'[^\''.Patterns::MARK.']*+\'|=[^\s>'.Patterns::MARK.']++)*)\s*+(/?)>#isu',
+			'#<(/?)([a-z][a-z0-9_:-]{0,50})((?:\s++[a-z0-9\_:-]++|=\s*+"[^"'.Patterns::MARK.']*+"|=\s*+\'[^\''.Patterns::MARK.']*+\'|=[^\s>'.Patterns::MARK.']++)*)\s*+(/?)>#isu',
 			'html/tag'
 		);
 
@@ -89,7 +89,7 @@ final class HtmlModule extends Texy\Module
 			// parse attributes
 			$matches2 = NULL;
 			preg_match_all(
-				'#([a-z0-9:-]+)\s*(?:=\s*(\'[^\']*\'|"[^"]*"|[^\'"\s]+))?()#isu',
+				'#([a-z0-9\_:-]+)\s*(?:=\s*(\'[^\']*\'|"[^"]*"|[^\'"\s]+))?()#isu',
 				$mAttr,
 				$matches2,
 				PREG_SET_ORDER


### PR DESCRIPTION
This have relation with data-* attributes. We need to support different marketing codes.

Signed-off-by: Kristián Feldsam <feldsam@gmail.com>

- bug fix? no   <!-- #issue numbers, if any -->
- new feature? yes
- BC break? no
